### PR TITLE
[Phase 2.7] feat: detect external package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -328,12 +328,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "contourpy"
@@ -763,7 +763,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -1675,7 +1675,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -1895,7 +1895,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -2152,7 +2152,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -2237,7 +2237,7 @@ version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
     {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
@@ -3304,4 +3304,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "3c0391359c43a36dae1156b04e208b1ce6ae3477b9d49adcbc6dfa9454b09c0e"
+content-hash = "555631ff77d5084f6e8cc11edec6c1a42dad293b72a0e925fe6b05932bfaa3c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,12 @@ dependencies = [
 [tool.poetry]
 packages = [{include = "code_graph_rag", from = "src"}]
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-pythonpath = ["."]
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.4.1"
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/src/code_graph_rag/main.py
+++ b/src/code_graph_rag/main.py
@@ -17,7 +17,7 @@ def parser():
             print(node)
 
 def test_ast():
-    project_path = Path("tests/overrides_edge_test")
+    project_path = Path("sample_repo")
     parser = ASTParser(project_root=project_path)
     nodes, edges= parser.parse()
 

--- a/src/code_graph_rag/parser/ast_parser.py
+++ b/src/code_graph_rag/parser/ast_parser.py
@@ -1,8 +1,10 @@
 import os
 import ast
+import re
 from pathlib import Path
-from typing import Any
 import builtins
+import tomllib
+import glob
 
 from src.code_graph_rag.models.nodes import *
 from src.code_graph_rag.models.edges import *
@@ -10,6 +12,8 @@ from src.code_graph_rag.models.edges import *
 class ASTParser():
     def __init__(self, project_root: str):
         self.project_root = Path(project_root).resolve()
+        self.project_name = self.project_root.name  # Name of the project root directory
+
         self.nodes = []
         self.edges = []
         # Maps folder paths to their qualified names when they are Python packages
@@ -28,10 +32,14 @@ class ASTParser():
 
         self.class_method_symbols = {}  # {class_qname: {method_name: method_qualified_name}}
         self.class_bases = {}          # {class_qname: [base_class_target]}
+
+        # External packages cache: normalized_name -> ExternalPackageNode
+        self.external_packages: dict[str, ExternalPackageNode] = {}
     
     def parse(self) -> tuple[list, list]:
         """Run the full parse and return lists of node and edge objects."""
         self._walk_files_and_dirs()
+        self._parse_dependencies_from_manifest()
         self._handle_overrides()
         return self.nodes, self.edges
     
@@ -190,6 +198,181 @@ class ASTParser():
                         target=str(rel_file_path),     # File uses path as identifier
                         type="CONTAINS_FILE"
                     ))
+
+    def _parse_dependencies_from_manifest(self):
+        """
+        Discover declared external dependencies from project manifest files
+        (prefer `pyproject.toml`, fall back to `requirements*.txt`) and
+        materialize them into the graph as:
+        1) ExternalPackageNode(name=<normalized>, version_spec=<constraint>)
+        2) Project-level edges: ProjectNode --DEPENDS_ON_EXTERNAL--> ExternalPackageNode
+
+        Why this method exists
+        ----------------------
+        - “ImportsEdge” found in source files tell us which *modules* are used,
+        but they don’t tell us the *declared* dependency list nor version constraints.
+        - The manifest is the source of truth for declared packages and versions.
+        - We emit **Project → DEPENDS_ON_EXTERNAL** edges for the whole project to capture
+        declared intent, independent of which modules import what.
+
+        What counts as a dependency
+        ---------------------------
+        - `pyproject.toml`:
+            * PEP 621: `[project].dependencies` (list of strings)
+            * Optional deps: `[project.optional-dependencies]` (dict of lists)
+            * Poetry: `[tool.poetry.dependencies]` (dict; ignore `"python"`)
+            * Poetry groups (optional): `[tool.poetry.group.*.dependencies]` (dict)
+        If `pyproject.toml` exists, it is preferred and we do not look at `requirements*.txt`
+        unless you want to merge (this implementation *does* merge if both exist).
+        - `requirements*.txt` (fallback or merge):
+            * Each non-empty, non-comment line is parsed via `_split_req_line()`.
+
+        Idempotency & deduplication
+        ---------------------------
+        - `_upsert_external_package()` guarantees one node per normalized package name and
+        upgrades `version_spec` when we learn more (e.g., from manifest).
+        - We deduplicate **Project-level** DEPENDS_ON_EXTERNAL edges by checking existing edges
+        where `source == self.project_name`.
+
+        Side effects
+        ------------
+        - Appends new ExternalPackageNode objects to `self.nodes` (only on first sight).
+        - Appends new Project-level DependsOnExternalEdge objects to `self.edges`
+        (only if not already present).
+        - Safe to call multiple times.
+
+        Examples
+        --------
+        pyproject.toml (PEP 621):
+            [project]
+            dependencies = [
+                "requests>=2.31,<3",
+                "pydantic>=2",
+            ]
+
+        requirements.txt:
+            numpy
+            pandas>=2.1,<3  # pinned range
+
+        Both inputs will produce ExternalPackageNode("requests", ">=2.31,<3"), etc.,
+        and ProjectNode("proj") --DEPENDS_ON_EXTERNAL--> ExternalPackageNode("requests").
+        """
+        # Collect all dependencies we discover into a temporary dict:
+        #   normalized_package_name -> version_spec (string, possibly empty)
+        # If the same package is found multiple times, last one wins (which is fine;
+        # `_upsert_external_package` merges/keeps the most informative spec).
+        discovered: dict[str, str] = {}
+
+        # Utility to add a (name, spec) into the `discovered` dict consistently:
+        def _record_dep(raw_name: str, spec: str) -> None:
+            if not raw_name:
+                return
+            # We do *not* normalize here; let _upsert_external_package() do normalization
+            # so that all normalization rules remain in one place.
+            # However, for dict keying we *do* want stable keys; use the same normalization
+            # as the node creation to avoid duplicate inserts in this local dict.
+            norm = self._norm_pkg_name(raw_name)
+            # Prefer non-empty spec if we already recorded an empty one earlier.
+            if norm in discovered:
+                if not discovered[norm] and spec:
+                    discovered[norm] = spec
+            else:
+                discovered[norm] = spec or ""
+
+        # ----------------------------------------------------------
+        # 1) Parse pyproject.toml if present (preferred information)
+        # ----------------------------------------------------------
+    
+        pyproject = Path(self.project_root) / "pyproject.toml"
+        if pyproject.exists():
+            try:
+                data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            except Exception:
+                data = {}
+
+            # PEP 621: [project].dependencies (list of strings)
+            for item in (data.get("project", {}) or {}).get("dependencies", []) or []:
+                result = self._split_req_line(item)
+                if result:
+                    name, spec = result
+                    _record_dep(name, spec)
+            
+            # PEP 621 optional dependencies: [project.optional-dependencies]
+            # Structure: { "extra_name": ["pkg1", "pkg2>=1", ...], ... }
+            opt_deps = (data.get("project", {}) or {}).get("optional-dependencies", {}) or {}
+            for _extra, lines in opt_deps.items():
+                for item in lines or []:
+                    result = self._split_req_line(item)
+                    if result:
+                        name, spec = result
+                        _record_dep(name, spec)
+            
+            # Poetry: [tool.poetry.dependencies]  (dict: name -> spec or table)
+            poetry_deps = (data.get("tool", {}) or {}).get("poetry", {}).get("dependencies", {}) or {}
+            for name, spec in poetry_deps.items():
+                if str(name).lower() == "python":
+                    continue  # Not a distribution; it's the interpreter constraint.
+                # Poetry can express version as a string or as a table with `version` field.
+                if isinstance(spec, str):
+                    _record_dep(name, spec)
+                elif isinstance(spec, dict):
+                    _record_dep(name, spec.get("version", ""))
+                
+            # Poetry groups (optional): [tool.poetry.group.<grp>.dependencies]
+            poetry_groups = (data.get("tool", {}) or {}).get("poetry", {}).get("group", {}) or {}
+            for _grp, section in poetry_groups.items():
+                group_deps = (section or {}).get("dependencies", {}) or {}
+                for name, spec in group_deps.items():
+                    if isinstance(spec, str):
+                        _record_dep(name, spec)
+                    elif isinstance(spec, dict):
+                        _record_dep(name, spec.get("version", ""))
+            
+        # ----------------------------------------------------------------
+        # 2) requirements*.txt fallback/merge (only if files actually exist)
+        # ----------------------------------------------------------------
+        # If we haven't discovered any dependencies yet, fall back to requirements files.
+        if not discovered:
+            req_glob = str(Path(self.project_root) / "requirements*.txt")
+            for req_path in glob.glob(req_glob):
+                try:
+                    with open(req_path, "r", encoding="utf-8") as f:
+                        for raw_line in f:
+                            result = self._split_req_line(raw_line)
+                            if not result:
+                                continue
+                            name, spec = result
+                            _record_dep(name, spec)
+                except OSError:
+                    # Non-fatal: skip unreadable files
+                    continue
+
+        # ----------------------------------------------------------------------
+        # 3) Upsert nodes and emit Project-level DEPENDS_ON_EXTERNAL edges (dedup)
+        # ----------------------------------------------------------------------
+        # Build a set of already-emitted project-level dependencies to avoid duplicates,
+        # while leaving module-level edges untouched.
+        already_emitted = {
+            e.target
+            for e in self.edges
+            if getattr(e, "type", None) == "DEPENDS_ON_EXTERNAL"
+            and getattr(e, "source", None) == self.project_name
+        }
+
+        for norm_pkg, spec in discovered.items():
+            # Ensure there is a node for this package (create or update version_spec).
+            node = self._upsert_external_package(norm_pkg, spec)
+
+            # Emit Project → DEPENDS_ON_EXTERNAL only once per package.
+            if node.name not in already_emitted:
+                self.edges.append(
+                    DependsOnExternalEdge(
+                        source=self.project_name,  # Project node identifier
+                        target=node.name,          # External package node name (normalized)
+                        type="DEPENDS_ON_EXTERNAL"
+                    )
+                )
+                already_emitted.add(node.name)
 
     def _parse_module(self, module_path: Path, mod_qname: str):
         with open(module_path, "r", encoding="utf-8") as f:
@@ -475,6 +658,138 @@ class ASTParser():
                         ))
                     # Nếu base là external (tên raw string), skip
         
+    @staticmethod
+    def _split_req_line(line: str) -> tuple[str, str] | None:
+        """
+        Parse a single requirement spec line into (package_name, version_spec).
+
+        This function is intentionally robust for common requirement formats found in
+        pyproject/requirements files. It supports:
+          - Simple pins:        "requests==2.31.0"
+          - Ranges:             "pandas>=2.1,<3"
+          - No version:         "numpy"
+          - Extras:             "uvicorn[standard]>=0.27"
+          - Env markers:        "Pillow>=10 ; python_version >= '3.10'"
+          - Inline comments:    "PyYAML>=6.0  # for config"
+          - Editable/VCS lines: "-e git+https://...#egg=package"  (returns ("package",""))
+
+        Returns:
+            (name, spec) if a package name can be extracted, otherwise None for
+            lines that are empty, comment-only, or unsupported.
+
+        Notes:
+            - The returned name is *raw* (not PEP 503 normalized). Normalization
+              should be applied by the caller (e.g., inside _upsert_external_package).
+            - The spec is returned exactly as it appears after the operator
+              (e.g., ">=2.1,<3"). If no version is present, spec = "".
+        """
+        if not line:
+            return None
+        
+        s = line.strip()
+        if not s or s.startswith("#"):
+            return None
+        
+        # Drop inline comments: "pkg>=1  # comment" -> "pkg>=1"
+        if "#" in s:
+            s = s.split("#", 1)[0].strip()
+        if not s:
+            return None
+        
+        # Drop environment markers: "pkg>=1 ; python_version >= '3.10'"
+        if ";" in s:
+            s = s.split(";", 1)[0].strip()
+        if not s:
+            return None
+        
+        # Handle editable/VCS lines (best-effort):
+        #   -e git+...#egg=package
+        #   git+...#egg=package
+        editable_prefixes = ("-e ", "--editable ")
+        if s.startswith(editable_prefixes) or s.startswith("git+"):
+            m = re.search(r"[#&]egg=([A-Za-z0-9_.\-]+)", s)
+            if m:
+                return m.group(1), ""
+            # If we cannot extract a name, skip this line silently
+            return None
+        
+        # Strip extras: "uvicorn[standard]" -> "uvicorn"
+        # We only drop the extras segment; the version part (if any) follows after.
+        # We find the first version operator and split before it; extras are removed from the name part.
+        # Supported operators (ordered by length so longer ones match first).
+        operators = ("==", ">=", "<=", ">", "<", "~=", "!=")
+        op_pos = len(s)
+        op_used = None
+        for op in operators:
+            pos = s.find(op)
+            if pos != -1 and pos < op_pos:
+                op_pos, op_used = pos, op
+        
+        if op_used is None:
+            # No version operator found: entire string is the package token (possibly with extras)
+            name_part = s
+            spec_part = ""
+
+        else:
+            name_part = s[:op_pos].rstrip()
+            spec_part = s[op_pos:].strip()  # keep the operator and everything after
+        
+        # Remove extras from the name part: "pkg[foo,bar]" -> "pkg"
+        if "[" in name_part:
+            name_part = name_part.split("[", 1)[0].strip()
+        
+        # Empty name → skip
+        if not name_part:
+            return None
+
+        return name_part, spec_part
+
+    @staticmethod
+    def _norm_pkg_name(name: str) -> str:
+        """
+        Normalize a distribution name per PEP 503:
+          - lowercase
+          - collapse runs of -, _, . into single '-'
+        This guarantees that different spellings of the same distribution map to one key.
+        """
+        name = name.strip().lower()
+        return re.sub(r"[-_.]+", "-", name)
+
+    def _upsert_external_package(self, pkg_name: str, version_spec: str | None = "") -> ExternalPackageNode:
+        """
+        Create or update an ExternalPackageNode in the parser's state.
+
+        This method ensures:
+          1) We only ever keep one node per *normalized* package name.
+          2) If a node already exists with empty version_spec and we now have a non-empty
+             version_spec (e.g., discovered from pyproject.toml), we update the node in-place.
+          3) The node is appended to `self.nodes` only on first creation (no duplicates).
+
+        Args:
+            pkg_name:     A raw distribution name as it appears in import/manifest (e.g., "Pillow", "cv2").
+            version_spec: The version constraint string (e.g., ">=2.31,<3"). If unknown, pass "".
+
+        Returns:
+            The ExternalPackageNode instance representing this distribution.
+        """
+
+        # Normalize the name so that "PyYAML", "pyyaml", "yaml" (after mapping) merge consistently.
+        norm = self._norm_pkg_name(pkg_name)
+        node = self.external_packages.get(norm)
+
+        if node is None:
+            # First time we see this package → create the node and cache it.
+            node = ExternalPackageNode(name=norm, version_spec=version_spec or "")
+            self.external_packages[norm] = node
+            self.nodes.append(node)
+            return node
+
+        # Node already exists: upgrade version_spec if previously unknown/empty.
+        if not getattr(node, "version_spec", "") and version_spec:
+            node.version_spec = version_spec
+
+        return node
+
 
 if __name__ == "__main__":
     parser = ASTParser("tests/sample_repo/")

--- a/src/code_graph_rag/parser/ast_parser.py
+++ b/src/code_graph_rag/parser/ast_parser.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import builtins
 import tomllib
 import glob
+from collections import defaultdict
 
 from src.code_graph_rag.models.nodes import *
 from src.code_graph_rag.models.edges import *
@@ -35,6 +36,7 @@ class ASTParser():
 
         # External packages cache: normalized_name -> ExternalPackageNode
         self.external_packages: dict[str, ExternalPackageNode] = {}
+        self.mod_to_external_used: dict[str, set[str]] = defaultdict(set)
     
     def parse(self) -> tuple[list, list]:
         """Run the full parse and return lists of node and edge objects."""
@@ -443,8 +445,14 @@ class ASTParser():
                         import_name=full_name        # Textual module path as written in code
                     ))
 
+                    # Record external use for this module
+                    self._record_external_use(mod_qname, full_name, is_relative=False)
+
             # ----- Case B: `from pkg.mod import name [as alias]` -----
             elif isinstance(node, ast.ImportFrom):  # Handle `from ... import ...` forms (supports relative imports)
+                # Relative if node.level > 0
+                is_rel = node.level and node.level > 0
+                
                 module_part = node.module or ""  # Base specified after `from`; empty for `from . import X`
                 # compute base qname for relative imports
                 if node.level > 0:  # node.level counts leading dots in `from ....` (number of package levels to go up)
@@ -477,6 +485,9 @@ class ASTParser():
                         type="IMPORTS",             # Relationship label
                         import_name=import_name     # Normalized textual import path
                     ))
+
+                    # Record external use for this module
+                    self._record_external_use(mod_qname, module_part, is_relative=is_rel)
 
     def _handle_class(self, node: ast.ClassDef, mod_qname: str, context_stack: list):
         qualified_name = f"{mod_qname}.{node.name}"
@@ -657,7 +668,81 @@ class ASTParser():
                             type="OVERRIDES"
                         ))
                     # Nếu base là external (tên raw string), skip
-        
+    
+    def _record_external_use(self, mod_qname: str, import_name: str, is_relative: bool = False) -> None:
+        """
+        Decide whether `import_name` (e.g., "numpy", "PIL.Image") used by `mod_qname`
+        is an *external* dependency and, if yes, emit a module-level
+        DEPENDS_ON_EXTERNAL edge to the corresponding ExternalPackageNode.
+
+        Parameters
+        ----------
+        mod_qname : str
+            Qualified name of the current module (e.g., "proj.pkg.mod").
+        import_name : str
+            The (already resolved) import token. For ImportFrom, we pass the base
+            module part (e.g., "requests.exceptions", "PIL") rather than the leaf symbol.
+        is_relative : bool, keyword-only
+            True if the originating ImportFrom was relative (node.level > 0).
+            Relative imports are *always internal*, so they must be skipped here.
+
+        Behavior
+        --------
+        1) If `is_relative` is True → skip (internal by definition).
+        2) If top-level token or the entire `import_name` is recognized as *internal*
+        (present in `self.module_symbols`) → skip.
+        3) Otherwise map known module→package (PIL→Pillow, cv2→opencv-python, ...),
+        normalize the package name (PEP 503), upsert ExternalPackageNode (spec = ""),
+        and emit a single module-level DEPENDS_ON_EXTERNAL edge (deduplicated per module).
+
+        Notes
+        -----
+        - This method is idempotent. Repeated calls for the same (module, package)
+        will not create duplicate edges thanks to `self.mod_to_external_used`.
+        """
+        # 1) Relative imports are always internal
+        if is_relative:
+            return
+
+        if not import_name:
+            return
+
+        # 2) Extract top-level token: "a.b.c" -> "a"
+        top = import_name.split(".", 1)[0]
+
+        # 3) Internal module discovered in Phase 2.2? -> skip
+        if top in self.module_symbols or import_name in self.module_symbols:
+            return
+
+        # 4) Map to distribution name and normalize
+        mapper = getattr(self, "WELL_KNOWN_IMPORT_TO_PKG", None)
+        if mapper is None:
+            # Fallback to a module-level constant if you keep it there.
+            try:
+                mapper = WELL_KNOWN_IMPORT_TO_PKG
+            except NameError:
+                mapper = {}
+        raw_pkg = mapper.get(top, top)
+        norm_pkg = self._norm_pkg_name(raw_pkg)
+
+        # 5) Dedup per module
+        used = self.mod_to_external_used.setdefault(mod_qname, set())
+        if norm_pkg in used:
+            return
+
+        # 6) Ensure node exists (spec may be filled later by manifest)
+        self._upsert_external_package(norm_pkg, "")
+
+        # 7) Emit Module -> DEPENDS_ON_EXTERNAL
+        self.edges.append(
+            DependsOnExternalEdge(
+                source=mod_qname,
+                target=norm_pkg,
+                type="DEPENDS_ON_EXTERNAL",
+            )
+        )
+        used.add(norm_pkg)
+
     @staticmethod
     def _split_req_line(line: str) -> tuple[str, str] | None:
         """
@@ -790,6 +875,15 @@ class ASTParser():
 
         return node
 
+WELL_KNOWN_IMPORT_TO_PKG = {
+    "cv2": "opencv-python",
+    "PIL": "Pillow",
+    "yaml": "PyYAML",
+    "dateutil": "python-dateutil",
+    "bs4": "beautifulsoup4",
+    "skimage": "scikit-image",
+    "Crypto": "pycryptodome",
+}
 
 if __name__ == "__main__":
     parser = ASTParser("tests/sample_repo/")

--- a/tests/parser/test_phase2_1_parse_filesystem.py
+++ b/tests/parser/test_phase2_1_parse_filesystem.py
@@ -1,0 +1,283 @@
+import pytest
+from pathlib import Path
+
+from src.code_graph_rag.parser.ast_parser import ASTParser
+from src.code_graph_rag.models.nodes import *
+from src.code_graph_rag.models.edges import *
+
+
+@pytest.fixture
+def make_fs(tmp_path):
+    """
+    Create a reproducible project root named 'proj' under the pytest tmp_path
+    and return a helper to materialize a file/folder structure, run ASTParser,
+    and return the parser.
+
+    The structure is described as a list of relative POSIX paths from 'proj/'.
+    - Directories end with '/'
+    - Regular files are created empty
+    - Python files create modules
+    - A directory containing '__init__.py' is treated as a Package
+    """
+    proj_root = tmp_path / "proj"
+    proj_root.mkdir()
+
+    def _make(structure: list[str]):
+        # Materialize structure
+        for rel in structure:
+            rel_path = Path(rel)
+            if rel.endswith("/"):
+                (proj_root / rel_path).mkdir(parents=True, exist_ok=True)
+            else:
+                file_path = proj_root / rel_path
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                file_path.write_text("", encoding="utf-8")
+
+        # Run parser only for filesystem walking phase
+        p = ASTParser(project_root=str(proj_root))
+        # Prefer calling the walker to avoid coupling with later phases
+        p._walk_files_and_dirs()
+        return p
+
+    return _make
+
+def contains_edges_as_tuples(p: ASTParser):
+    return sorted(
+        (e.source, e.type, e.target) for e in p.edges if isinstance(e, ContainsEdge)
+    )
+
+def nodes_summary(p: ASTParser):
+    """Summarize nodes by type and identifier (name/path/qualified_name)."""
+    proj = [n.name for n in p.nodes if isinstance(n, ProjectNode)]
+    folders = [n.path for n in p.nodes if isinstance(n, FolderNode)]
+    packages = [n.qualified_name for n in p.nodes if isinstance(n, PackageNode)]
+    modules = [n.qualified_name for n in p.nodes if isinstance(n, ModuleNode)]
+    files = [n.path for n in p.nodes if isinstance(n, FileNode)]
+    return {
+        "ProjectNode": sorted(proj),
+        "FolderNode": sorted(set(folders)),
+        "PackageNode": sorted(set(packages)),
+        "ModuleNode": sorted(set(modules)),
+        "FileNode": sorted(set(files)),
+    }
+
+@pytest.mark.parametrize(
+    "structure, expected_edges, expected_nodes",
+    [
+        # 0) Empty project
+        (
+            [],
+            [],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": [],
+                "PackageNode": [],
+                "ModuleNode": [],
+                "FileNode": [],
+            }
+        ),
+
+        # 1) Simple project with a non-Python file
+        (
+            [
+                "docs/",
+                "docs/readme.txt",
+            ],
+            [
+                ("proj", "CONTAINS_FOLDER", "docs"),
+                ("docs", "CONTAINS_FILE", "docs/readme.txt"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": ["docs"],
+                "PackageNode": [],
+                "ModuleNode": [],
+                "FileNode": ["docs/readme.txt"],
+            },
+        ),
+        # 2) Root-level module and non-code file
+        (
+            [
+                "app.py",
+                "README.md",
+            ],
+            [
+                ("proj", "CONTAINS_MODULE", "proj.app"),
+                ("proj", "CONTAINS_FILE", "README.md"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": [],
+                "PackageNode": [],
+                "ModuleNode": ["proj.app"],
+                "FileNode": ["README.md"],
+            },
+        ),
+        # 3) Root-level package with module (includes __init__.py as a module)
+        (
+            [
+                "pkg/__init__.py",
+                "pkg/m.py",
+            ],
+            [
+                ("proj", "CONTAINS_PACKAGE", "proj.pkg"),
+                ("proj.pkg", "CONTAINS_MODULE", "proj.pkg.__init__"),
+                ("proj.pkg", "CONTAINS_MODULE", "proj.pkg.m"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": [],
+                "PackageNode": ["proj.pkg"],
+                "ModuleNode": ["proj.pkg.__init__", "proj.pkg.m"],
+                "FileNode": [],
+            },
+        ),
+        # 4) Nested package with subpackage and module (includes both __init__.py modules)
+        (
+            [
+                "pkg/__init__.py",
+                "pkg/sub/__init__.py",
+                "pkg/sub/n.py",
+            ],
+            [
+                ("proj", "CONTAINS_PACKAGE", "proj.pkg"),
+                ("proj.pkg", "CONTAINS_MODULE", "proj.pkg.__init__"),
+                ("proj.pkg", "CONTAINS_PACKAGE", "proj.pkg.sub"),
+                ("proj.pkg.sub", "CONTAINS_MODULE", "proj.pkg.sub.__init__"),
+                ("proj.pkg.sub", "CONTAINS_MODULE", "proj.pkg.sub.n"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": [],
+                "PackageNode": ["proj.pkg", "proj.pkg.sub"],
+                "ModuleNode": ["proj.pkg.__init__", "proj.pkg.sub.__init__", "proj.pkg.sub.n"],
+                "FileNode": [],
+            },
+        ),
+        # 5) Folder containing a module (folder is not a package)
+        (
+            [
+                "lib/",
+                "lib/util.py",
+            ],
+            [
+                ("proj", "CONTAINS_FOLDER", "lib"),
+                ("lib", "CONTAINS_MODULE", "proj.lib.util"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": ["lib"],
+                "PackageNode": [],
+                "ModuleNode": ["proj.lib.util"],
+                "FileNode": [],
+            },
+        ),
+        # 6) Package containing a regular folder with a non-python file (includes __init__.py module)
+        (
+            [
+                "pkg/__init__.py",
+                "pkg/docs/",
+                "pkg/docs/guide.txt",
+            ],
+            [
+                ("proj", "CONTAINS_PACKAGE", "proj.pkg"),
+                ("proj.pkg", "CONTAINS_MODULE", "proj.pkg.__init__"),
+                ("proj.pkg", "CONTAINS_FOLDER", "pkg/docs"),
+                ("pkg/docs", "CONTAINS_FILE", "pkg/docs/guide.txt"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": ["pkg/docs"],
+                "PackageNode": ["proj.pkg"],
+                "ModuleNode": ["proj.pkg.__init__"],
+                "FileNode": ["pkg/docs/guide.txt"],
+            },
+        ),
+        # 7) Mixed root: module, file, folder->module, package->module (package includes __init__.py module)
+        (
+            [
+                "root_mod.py",
+                "data.txt",
+                "a/",
+                "a/x.py",
+                "pkg/__init__.py",
+                "pkg/m.py",
+            ],
+            [
+                ("proj", "CONTAINS_MODULE", "proj.root_mod"),
+                ("proj", "CONTAINS_FILE", "data.txt"),
+                ("proj", "CONTAINS_FOLDER", "a"),
+                ("a", "CONTAINS_MODULE", "proj.a.x"),
+                ("proj", "CONTAINS_PACKAGE", "proj.pkg"),
+                ("proj.pkg", "CONTAINS_MODULE", "proj.pkg.__init__"),
+                ("proj.pkg", "CONTAINS_MODULE", "proj.pkg.m"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": ["a"],
+                "PackageNode": ["proj.pkg"],
+                "ModuleNode": ["proj.a.x", "proj.pkg.__init__", "proj.pkg.m", "proj.root_mod"],
+                "FileNode": ["data.txt"],
+            },
+        ),
+        # 8) Package directly contains a non-python file (package -> file) and includes __init__.py module
+        (
+            [
+                "pkg/__init__.py",
+                "pkg/README.md",
+            ],
+            [
+                ("proj", "CONTAINS_PACKAGE", "proj.pkg"),
+                ("proj.pkg", "CONTAINS_MODULE", "proj.pkg.__init__"),
+                ("proj.pkg", "CONTAINS_FILE", "pkg/README.md"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": [],
+                "PackageNode": ["proj.pkg"],
+                "ModuleNode": ["proj.pkg.__init__"],
+                "FileNode": ["pkg/README.md"],
+            },
+        ),
+        # 9) Nested folders: folder -> folder -> module
+        (
+            [
+                "a/",
+                "a/b/",
+                "a/b/c.py",
+            ],
+            [
+                ("proj", "CONTAINS_FOLDER", "a"),
+                ("a", "CONTAINS_FOLDER", "a/b"),
+                ("a/b", "CONTAINS_MODULE", "proj.a.b.c"),
+            ],
+            {
+                "ProjectNode": ["proj"],
+                "FolderNode": ["a", "a/b"],
+                "PackageNode": [],
+                "ModuleNode": ["proj.a.b.c"],
+                "FileNode": [],
+            },
+        ),
+    ],
+)
+def test_phase2_1_parse_filesystem(
+    make_fs,
+    structure: list[str],
+    expected_edges: list[tuple[str, str, str]],
+    expected_nodes: dict[str, list[str]],
+):
+    """
+    Test the filesystem parsing phase of the ASTParser.
+    It should correctly identify folders, packages, modules, and files.
+    """
+    parser = make_fs(structure)
+
+    # Verify CONTAINS_* edges
+    got_edges = contains_edges_as_tuples(parser)
+    want_edges = sorted(expected_edges)
+    assert got_edges == want_edges, f"Edges mismatch.\nGot:   {got_edges}\nWant:  {want_edges}"
+
+    # Verify nodes by type/identifier
+    got_nodes = nodes_summary(parser)
+    assert got_nodes == expected_nodes, f"Nodes mismatch.\nGot:   {got_nodes}\nWant:  {expected_nodes}"

--- a/tests/parser/test_phase2_6_parse_imports.py
+++ b/tests/parser/test_phase2_6_parse_imports.py
@@ -1,5 +1,3 @@
-import sys
-print(sys.path)
 import pytest
 from src.code_graph_rag.models.edges import ImportsEdge
 from src.code_graph_rag.parser.ast_parser import ASTParser

--- a/tests/parser/test_phase2_7_parse_external_manifest.py
+++ b/tests/parser/test_phase2_7_parse_external_manifest.py
@@ -1,0 +1,153 @@
+import os
+import textwrap
+import pytest
+
+from src.code_graph_rag.parser.ast_parser import ASTParser
+from src.code_graph_rag.models.nodes import ExternalPackageNode
+from src.code_graph_rag.models.edges import DependsOnExternalEdge
+
+def _collect_external_nodes(nodes):
+    """Return a dict: name -> node for ExternalPackageNode."""
+    return {n.name: n for n in nodes if isinstance(n, ExternalPackageNode)}
+
+
+def _project_dep_edges(edges, project_name: str | None = None):
+    """
+    Return all project-level DEPENDS_ON_EXTERNAL edges.
+    If project_name is provided, filter by source == project_name.
+    """
+    out = [e for e in edges if isinstance(e, DependsOnExternalEdge)]
+    if project_name is not None:
+        out = [e for e in out if getattr(e, "source", None) == project_name]
+    return out
+
+def _edge_targets(edges):
+    """Helper: return set of edge.target from a list of edges."""
+    return {e.target for e in edges}
+
+def test_pep621_dependencies(tmp_path):
+    """
+    PEP 621: [project].dependencies as a list of strings should produce
+    ExternalPackageNodes and Project -> DEPENDS_ON_EXTERNAL edges.
+    """
+    pyproj = tmp_path / "pyproject.toml"
+    pyproj.write_text(textwrap.dedent("""
+        [project]
+        name = "demo"
+        version = "0.0.1"
+        dependencies = [
+            "requests>=2.31,<3",
+            "pydantic>=2",
+        ]
+    """).strip(), encoding="utf-8")
+
+    parser = ASTParser(project_root=tmp_path)
+    nodes, edges = parser.parse()
+
+    project_name = getattr(parser, "project_name", tmp_path.name)
+    deps = _project_dep_edges(edges, project_name)
+    targets = _edge_targets(deps)
+
+    # External nodes present
+    ext = _collect_external_nodes(nodes)
+    assert "requests" in ext and "pydantic" in ext
+    assert ext["requests"].version_spec == ">=2.31,<3"
+    assert ext["pydantic"].version_spec == ">=2"
+
+    # Project-level edges present
+    assert {"requests", "pydantic"} <= targets
+
+def test_pep621_optional_dependencies(tmp_path):
+    """
+    PEP 621: [project.optional-dependencies] should be merged and emitted
+    as ExternalPackageNode + Project-level DEPENDS_ON_EXTERNAL edges.
+    """
+    pyproj = tmp_path / "pyproject.toml"
+    pyproj.write_text(textwrap.dedent("""
+        [project]
+        name = "demo"
+        version = "0.0.1"
+        dependencies = ["numpy"]
+
+        [project.optional-dependencies]
+        image = ["Pillow==10.0.0"]
+        dev = ["mypy>=1.7"]
+    """).strip(), encoding="utf-8")
+
+    parser = ASTParser(project_root=tmp_path)
+    nodes, edges = parser.parse()
+
+    project_name = getattr(parser, "project_name", tmp_path.name)
+    deps = _project_dep_edges(edges, project_name)
+    targets = _edge_targets(deps)
+
+    ext = _collect_external_nodes(nodes)
+    # Names are normalized per PEP 503 (lowercase, collapse punctuation to '-').
+    assert "numpy" in ext
+    assert "pillow" in ext
+    assert "mypy" in ext
+    assert ext["pillow"].version_spec == "==10.0.0"
+    assert {"numpy", "pillow", "mypy"} <= targets
+
+def test_poetry_dependencies_and_groups(tmp_path):
+    """
+    Poetry layout:
+      [tool.poetry.dependencies] (dict, ignore 'python')
+      [tool.poetry.group.<name>.dependencies] (dict)
+    should be parsed and merged.
+    """
+    pyproj = tmp_path / "pyproject.toml"
+    pyproj.write_text(textwrap.dedent("""
+        [tool.poetry]
+        name = "demo"
+        version = "0.0.1"
+
+        [tool.poetry.dependencies]
+        python = "^3.11"
+        Pillow = "^10.3"
+        pyyaml = ">=6"
+
+        [tool.poetry.group.dev.dependencies]
+        pytest = "^8.2"
+        mypy = { version = ">=1.7" }
+    """).strip(), encoding="utf-8")
+
+    parser = ASTParser(project_root=tmp_path)
+    nodes, edges = parser.parse()
+
+    project_name = getattr(parser, "project_name", tmp_path.name)
+    deps = _project_dep_edges(edges, project_name)
+    targets = _edge_targets(deps)
+
+    ext = _collect_external_nodes(nodes)
+    # 'python' should be ignored, others captured
+    assert "pillow" in ext and "pyyaml" in ext and "pytest" in ext and "mypy" in ext
+    assert ext["pillow"].version_spec == "^10.3"
+    assert ext["pyyaml"].version_spec == ">=6"
+    assert ext["pytest"].version_spec == "^8.2"
+    assert ext["mypy"].version_spec == ">=1.7"
+    assert {"pillow", "pyyaml", "pytest", "mypy"} <= targets
+
+def test_requirements_only(tmp_path):
+    """
+    If only requirements.txt exists, it should be parsed and emitted.
+    """
+    (tmp_path / "requirements.txt").write_text(textwrap.dedent("""
+        pandas>=2.2,<3
+        bs4
+        # comment line
+    """).strip(), encoding="utf-8")
+
+    parser = ASTParser(project_root=tmp_path)
+    nodes, edges = parser.parse()
+
+    project_name = getattr(parser, "project_name", tmp_path.name)
+    deps = _project_dep_edges(edges, project_name)
+    targets = _edge_targets(deps)
+
+    ext = _collect_external_nodes(nodes)
+    assert "pandas" in ext and "bs4" in ext
+    assert ext["pandas"].version_spec == ">=2.2,<3"
+    # No version for bs4
+    assert ext["bs4"].version_spec in ("", None)
+    assert {"pandas", "bs4"} <= targets

--- a/tests/parser/test_phase2_7_parse_external_usage.py
+++ b/tests/parser/test_phase2_7_parse_external_usage.py
@@ -1,0 +1,35 @@
+import pytest
+from src.code_graph_rag.parser.ast_parser import ASTParser
+from src.code_graph_rag.models.edges import DependsOnExternalEdge
+
+@pytest.fixture
+def make_parser(tmp_path):
+    """
+    Returns a function that writes `code` to a .py file under tmp_path,
+    runs ASTParser on it, and returns the parser instance.
+    """
+    def _make(code:str, module_qname: str = "proj.mod"):
+        # Write code to a temporary .py file
+        path = tmp_path / "mod.py"
+        path.write_text(code, encoding="utf-8")
+        # Instantiate ASTParser configured for this module
+        p = ASTParser(project_root=tmp_path)
+        p.module_symbols[module_qname] = module_qname
+        p._parse_module(path, module_qname)
+        return p
+    return _make
+
+@pytest.mark.parametrize("code, expect_pkgs", [
+    ("import requests", {"requests"}),
+    ("from PIL import Image", {"pillow"}),     # mapped
+    ("import cv2 as cv", {"opencv-python"}),   # mapped
+    ("from yaml import safe_load", {"pyyaml"}),# mapped
+    ("from .local import util", set()),        # relative -> skip
+    ("from ..pkg.sub import x", set()),          # relative -> skip
+    # ("import proj.internal", set()),           # internal -> skip (seed module_symbols)
+])
+def test_module_depends_edges(make_parser, code, expect_pkgs):
+    p = make_parser(code, module_qname="proj.mod")
+    depends = {e.target for e in p.edges if isinstance(e, DependsOnExternalEdge)
+               and e.source == "proj.mod"}
+    assert depends == expect_pkgs, f"Expected {expect_pkgs}, but got {depends} for code:\n{code}"


### PR DESCRIPTION
## Overview
Introduce ExternalPackage modeling and DEPENDS_ON_EXTERNAL edges in the code graph. This phase covers both:
- Declared deps from pyproject.toml / requirements*.txt → Project → ExternalPackage
- Observed usage from imports (Phase 2.6 hook) → Module → ExternalPackage

## Changes
- Manifest parsing (project-level deps)
  - Add _parse_dependencies_from_manifest() in ASTParser:
    - Supports PEP 621 [project].dependencies and [project.optional-dependencies]
    - Supports Poetry [tool.poetry.dependencies] (ignores python) and [tool.poetry.group.*.dependencies]
    - Merges requirements*.txt (robust split_req_line() for pins/ranges/extras/markers)
  - _upsert_external_package(name, version_spec) (idempotent; PEP 503 normalization)
  
- Import hook (module-level deps)
  - Extend Phase 2.6 _handle_imports() to call _record_external_use(...)
  - Add _record_external_use(mod_qname, import_name, *, is_relative=False):
    - Skip relative imports (from .x import y) and internal modules (via module_symbols/internal_module_roots)
    - Map known module→package (PIL→Pillow, cv2→opencv-python, yaml→PyYAML, etc.)
    - Normalize names (PEP 503), upsert node, dedup per module via mod_to_external_used
 
## How to Test
- pytest tests/parser/test_phase2_7_parse_external_manifest.py
- pytest tests/parser/test_phase2_7_parse_external_usage.py

## Related
- Builds on Phase 2.6 (imports) by attaching external dependency semantics

## Notes
- No breaking changes to existing node/edge schemas.
- _upsert_external_package and edge emission are idempotent; repeated runs won’t duplicate nodes/edges.
- PEP 503 normalization ensures consistent package keys.
- If running on Python < 3.11, use tomli as a fallback to tomllib.
- README/basic design docs updated for Phase 2.7 behavior and edge consistency