### PR TITLE
[Phase 3.2] feat: ResolverEntity

### DIFF
--- a/src/code_graph_rag/agent/graph_agent.py
+++ b/src/code_graph_rag/agent/graph_agent.py
@@ -8,12 +8,14 @@ from pydantic import BaseModel
 from src.code_graph_rag.agent.llm import get_cypher_generate_model
 from src.code_graph_rag.agent.utils.utils import run_cypher_query
 from src.code_graph_rag.agent.intent import llm_parse_intent, decide_route
-from src.code_graph_rag.agent.models import QueryIntent, Route
+from src.code_graph_rag.agent.resolver import resolve_entity
+from src.code_graph_rag.agent.models import QueryIntent, Route,  ResolvedEntity
 
 class GraphState(BaseModel):
     question: str | None = None
     intent: QueryIntent | None = None
     route: str | None = None
+    resolve: ResolvedEntity | None = None
     cypher_query: str | None = None
     matched_node: list[dict] | None = None
     code_snippets: list[str] | None = None
@@ -30,6 +32,11 @@ def parse_intent_node(state: GraphState) -> GraphState:
 def router_node(state: GraphState) -> GraphState:
     route = decide_route(state.intent) if state.intent else Route.FAST
     state.route = route.value
+    return state
+
+def resolve_entity_node(state: GraphState) -> GraphState:
+    if state.intent:
+        state.resolve = resolve_entity(state.intent)
     return state
 
 def graph_query_node(state: GraphState):
@@ -86,6 +93,7 @@ builder = StateGraph(GraphState)
 builder.add_node("UserQuestion", user_question_node)
 builder.add_node("ParseIntent", parse_intent_node)
 builder.add_node("Router", router_node)
+builder.add_node("ResolveEntity", resolve_entity_node)
 builder.add_node("GraphQuery", graph_query_node)
 builder.add_node("ContextRetrieval", context_trieval_node)
 builder.add_node("AnswerGeneration", answer_generation_node)
@@ -93,7 +101,8 @@ builder.add_node("AnswerGeneration", answer_generation_node)
 builder.set_entry_point("UserQuestion")
 builder.add_edge("UserQuestion", "ParseIntent")
 builder.add_edge("ParseIntent", "Router")
-builder.add_edge("Router", "GraphQuery")
+builder.add_edge("Router", "ResolveEntity")
+builder.add_edge("ResolveEntity", "GraphQuery")
 builder.add_edge("GraphQuery", "ContextRetrieval" )
 builder.add_edge("ContextRetrieval", "AnswerGeneration")
 builder.set_finish_point("AnswerGeneration")

--- a/src/code_graph_rag/agent/intent.py
+++ b/src/code_graph_rag/agent/intent.py
@@ -40,6 +40,8 @@ Rules:
 - If the question is Vietnamese, set "language":"vi", else "en".
 - If destination symbol is implied (trace/impact), fill "mention_dst".
 - Depth/limit/k_paths: choose sensible defaults if unspecified.
+- If a symbol is absent/unspecified, set its field to None (e.g., "mention": None).
+- Never output the string "none"/"null" for missing fields.
 - Do not include any extra fields or comments.
 """
 
@@ -87,14 +89,14 @@ def llm_parse_intent(question: str) -> QueryIntent:
         json.JSONDecodeError: If both attempts return non-JSON text.
         pydantic.ValidationError: If the JSON does not match the schema.
     """
-    log.debug("intent.question: %s", question)
+    log.debug("llm_parse_intent.question: %s", question)
     llm = get_cypher_generate_model()  # small/cheap model is OK
     prompt = ChatPromptTemplate.from_messages(
         [("system", JSON_INSTRUCTIONS), ("user", "{q}")]
     )
     chain = prompt | llm | StrOutputParser()
     raw = chain.invoke({"q": question})
-    log.debug("intent.raw_first: %s", raw)
+    log.debug("llm_parse_intent.raw_first: %s", raw)
 
     try:
         obj: dict[str, Any] = json.loads(raw)
@@ -102,11 +104,11 @@ def llm_parse_intent(question: str) -> QueryIntent:
         obj.setdefault("language", _detect_language(question))
 
         qi = QueryIntent.model_validate(obj)
-        log.debug("intent.validated_first: %s", qi.model_dump())
+        log.debug("llm_parse_intent.validated_first: %s", qi.model_dump())
 
         return qi
     except Exception as e:
-        log.error("intent.parse_error: %s", e)
+        log.error("llm_parse_intent.parse_error: %s", e)
         # one-shot repair with error hints
         repair = ChatPromptTemplate.from_messages(
             [("system", JSON_INSTRUCTIONS + REPAIR_HINT), ("user", "{q}")]
@@ -114,13 +116,13 @@ def llm_parse_intent(question: str) -> QueryIntent:
         fixed = (repair | llm | StrOutputParser()).invoke(
             {"q": question, "error": str(e)}
         )
-        log.debug("intent.raw_repair: %s", fixed)
+        log.debug("llm_parse_intent.raw_repair: %s", fixed)
 
         obj = json.loads(fixed)
         obj.setdefault("language", _detect_language(question))
         
         qi: QueryIntent = QueryIntent.model_validate(obj)
-        log.debug("intent.validated_repair: %s", qi.model_dump())
+        log.debug("llm_parse_intent.validated_repair: %s", qi.model_dump())
 
         return qi
 

--- a/src/code_graph_rag/agent/models.py
+++ b/src/code_graph_rag/agent/models.py
@@ -18,9 +18,6 @@ class Action(str, Enum):
 
 Language = Literal["vi", "en"]
 
-Route = Literal["fast", "plan"]
-
-
 class QueryIntent(BaseModel):
     """Normalized user intent for routing.
 
@@ -62,7 +59,26 @@ class Route(str, Enum):
     FAST = "FAST"
     PLAN = "PLAN"
 
+CandidateLabel = Literal[
+    "Project", "Package", "Module", "Class", "Function", "Method", "File", "Folder", "ExternalPackage"
+]
 
-def clamp_int(value: int, low: int, high: int) -> int:
-    """Clamp an integer to [low, high]."""
-    return max(low, min(high, value))
+class Candidate(BaseModel):
+    """One possible mapping for a textual mention."""
+    label: CandidateLabel
+    id: str                    # canonical identifier (qname / package name / path)
+    score: float               # 0..1
+    display: str               # human-friendly text
+
+class ResolvedEntity(BaseModel):
+    """Final resolution (and ranked alternatives) for source/destination mentions."""
+    resolved_label: CandidateLabel | None = None
+    resolved_id: str | None = None
+    confidence: float = 0.0
+    candidates: list[Candidate] = []
+    assumption: str | None = None
+
+    resolved_label_dst: CandidateLabel | None = None
+    resolved_id_dst: str | None = None
+    confidence_dst: float = 0.0
+    candidates_dst: list[Candidate] = []

--- a/src/code_graph_rag/agent/resolver.py
+++ b/src/code_graph_rag/agent/resolver.py
@@ -1,0 +1,322 @@
+"""Entity Resolver.
+
+Resolves free-text mentions (e.g. "main", "pkg.mod.Class") to canonical graph
+identifiers (qualified_name/path) using a sequence of parameterized Cypher
+queries and a deterministic ranker.
+
+WHY:
+    Planner/GraphQuery require precise node ids. This module converts user
+    mentions into (label, id, confidence) plus a ranked candidate list when
+    ambiguity exists.
+
+SECURITY:
+    * All Cypher queries are parameterized to avoid injection.
+    * Queries are allow-listed and bounded with LIMITs.
+
+PERF:
+    * Queries target indexed properties (qualified_name, name) wherever
+      possible. Fuzzy broad search is last resort with tight LIMITs.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from src.code_graph_rag.agent.models import (
+    Candidate,
+    QueryIntent,
+    ResolvedEntity,
+)
+from src.code_graph_rag.agent.utils.ranking import finalize_scores
+from src.code_graph_rag.agent.utils.utils import run_cypher_query  # provided by agent
+
+from src.code_graph_rag.utils.logging_setup import get_logger
+log = get_logger(__name__)
+
+
+# Confidence bands. Keep these in sync with design doc & Planner behavior.
+C_ACCEPT = 0.80
+C_MAYBE = 0.50
+WIN_MARGIN = 0.05
+
+
+def _rows_exact_qname(q: str) -> list[dict[str, Any]]:
+    """Return candidates with exact qualified_name match.
+
+    Args:
+        q: The fully-qualified name to match.
+
+    Returns:
+        List of dict rows: {"label", "id", "name"}.
+
+    Raises:
+        None. Upstream run_cypher_query should raise with context on failure.
+    """
+    cypher = """
+    MATCH (n)
+    WHERE (n:Module OR n:Class OR n:Function OR n:Method)
+      AND coalesce(n.qualified_name, '') = $q
+    RETURN head(labels(n)) AS label,
+           coalesce(n.qualified_name, n.path) AS id, n.name AS name
+    LIMIT 50
+    """
+    return run_cypher_query(cypher, {"q": q})
+
+
+def _rows_exact_name(name: str) -> list[dict[str, Any]]:
+    """Return candidates whose simple name equals `name`.
+
+    Searches Function, Method, and Class by exact `n.name = name`.
+    Module names vary per exporter, so Module is handled in suffix search.
+
+    Args:
+        name: The simple symbol name, e.g. "main".
+
+    Returns:
+        List of dict rows: {"label", "id", "name"}.
+    """
+    cypher = """
+    CALL {
+      WITH $name AS name
+      MATCH (n:Function) WHERE n.name = name
+      RETURN 'Function' AS label, n.qualified_name AS id, n.name AS name
+      UNION ALL
+      MATCH (n:Method) WHERE n.name = name
+      RETURN 'Method' AS label, n.qualified_name AS id, n.name AS name
+      UNION ALL
+      MATCH (n:Class) WHERE n.name = name
+      RETURN 'Class' AS label, n.qualified_name AS id, n.name AS name
+    }
+    RETURN label, id, name
+    LIMIT 200
+    """
+    return run_cypher_query(cypher, {"name": name})
+
+
+def _rows_suffix(name: str) -> list[dict[str, Any]]:
+    """Return Module candidates based on suffix/equals match.
+
+    WHY:
+        Users often mention a module by its stem (e.g., "util"), while the
+        graph stores fully-qualified module names.
+
+    Args:
+        name: Module stem or name.
+
+    Returns:
+        List of dict rows: {"label"="Module", "id", "name"}.
+    """
+    cypher = """
+    CALL {
+      WITH $name AS name
+      MATCH (m:Module)
+      WHERE m.qualified_name ENDS WITH '.' + name
+         OR m.name = name OR m.qualified_name = name
+      RETURN 'Module' AS label, m.qualified_name AS id, m.name AS name
+    }
+    RETURN label, id, name
+    LIMIT 200
+    """
+    return run_cypher_query(cypher, {"name": name})
+
+
+def _rows_contains(token: str) -> list[dict[str, Any]]:
+    """Return a broad set of candidates using CONTAINS, for fuzzy ranking.
+
+    WHY:
+        As a last resort when exact matches fail, gather plausible candidates
+        across labels and defer the final decision to the Python ranker.
+
+    Args:
+        token: A meaningful substring (often the longest segment of mention).
+
+    Returns:
+        List of dict rows: {"label", "id", "name"} across Module/Class/
+        Function/Method.
+    """
+    cypher = """
+    CALL {
+      WITH $t AS t
+      MATCH (n:Module) WHERE n.qualified_name CONTAINS t
+      RETURN 'Module' AS label, n.qualified_name AS id, n.name AS name
+      UNION ALL
+      MATCH (n:Class) WHERE n.qualified_name CONTAINS t OR n.name = t
+      RETURN 'Class' AS label, n.qualified_name AS id, n.name AS name
+      UNION ALL
+      MATCH (n:Function) WHERE n.qualified_name CONTAINS t OR n.name = t
+      RETURN 'Function' AS label, n.qualified_name AS id, n.name AS name
+      UNION ALL
+      MATCH (n:Method) WHERE n.qualified_name CONTAINS t OR n.name = t
+      RETURN 'Method' AS label, n.qualified_name AS id, n.name AS name
+    }
+    RETURN label, id, name
+    LIMIT 400
+    """
+    return run_cypher_query(cypher, {"t": token})
+
+
+def _rank(mention: str, rows: list[dict[str, Any]]) -> list[Candidate]:
+    """Convert raw rows into ranked `Candidate` models.
+
+    Args:
+        mention: Original textual mention.
+        rows: Dict rows containing "label", "id", "name".
+
+    Returns:
+        A list of `Candidate` (label, id, score, display) sorted by score.
+
+    Algorithm:
+        1) Project rows to (label, id, name).
+        2) Use finalize_scores() to compute stable ranking.
+        3) Wrap into Candidate models with a human-friendly display.
+    """
+    tuples = [(r["label"], r["id"], r.get("name")) for r in rows]
+    log.debug("_rank.tuples: %s", tuples)
+    ranked = finalize_scores(tuples, mention)  # [(label, id, score)]
+    log.debug("_rank.ranked: %s", ranked)
+    return [
+        Candidate(label=lab, id=qid, score=sc, display=f"{lab}: {qid}")
+        for lab, qid, sc in ranked
+    ]
+
+
+def _choose(
+    cands: list[Candidate],
+) -> tuple[str | None, str | None, float, str | None]:
+    """Decide final pick (if any) from ranked candidates with a win-margin guard.
+
+    Policy:
+        - Auto-accept only if:
+            top.score >= C_ACCEPT and
+            (no runner-up or (top.score - runner_up.score) >= WIN_MARGIN).
+        - Else if top.score >= C_MAYBE:
+            ambiguous → return candidates with an assumption message.
+        - Else:
+            very uncertain.
+
+    WHY:
+        Exact-name ties across types (e.g., Method vs Function both at 0.90
+        base tier) should not auto-resolve merely due to small type boosts.
+        The win-margin guard prevents overconfident picks when alternatives
+        are close.
+
+    Returns:
+        (resolved_label, resolved_id, confidence, assumption_message)
+    """
+    if not cands:
+        return None, None, 0.0, "No candidates found"
+    top = cands[0]
+    runner_up = cands[1] if len(cands) > 1 else None
+    log.debug("_choose.top: %s", top)
+    log.debug("_choose.runner_up: %s", runner_up)
+
+    # Only auto-accept if top is confident AND clearly ahead.
+    if top.score >= C_ACCEPT and (runner_up is None or (top.score - runner_up.score) >= WIN_MARGIN):
+        return top.label, top.id, top.score, None
+
+    if top.score >= C_MAYBE:
+        return None, None, top.score, "Low confidence or close alternatives; showing candidates"
+
+    return None, None, top.score, "Very low confidence; likely ambiguous"
+
+
+def resolve_one(
+    mention: str,
+) -> tuple[str | None, str | None, float, list[Candidate], str | None]:
+    """Resolve a single mention to a node id with confidence and alternatives.
+
+    Heuristic order (early stop on first non-empty result set):
+        1) Exact qualified_name
+        2) Exact simple name (Function/Method/Class)
+        3) Module suffix / equals
+        4) CONTAINS (broad) + Python-side ranking
+
+    Args:
+        mention: Free-text mention provided by the user.
+
+    Returns:
+        (label, id, confidence, candidates, assumption_message)
+
+    Examples:
+        >>> resolve_one("proj.app.main")  # doctest: +SKIP
+        ('Function', 'proj.app.main', 1.0, [...], None)
+    """
+    m = (mention or "").strip()
+    log.debug("resolve_one.mention: %s", m)
+    if not m:
+        return None, None, 0.0, [], "Empty mention"
+
+    # 1) Exact qname
+    rows: list[dict[str, Any]] = _rows_exact_qname(m)
+    log.debug("resolve_one.exact_qname_rows: %s", rows)
+
+    # 2) Exact simple name
+    if not rows:
+        rows = _rows_exact_name(m)
+        log.debug("resolve_one.exact_name_rows: %s", rows)
+
+    # 3) Module suffix
+    if not rows:
+        rows = _rows_suffix(m)
+        log.debug("resolve_one.suffix_rows: %s", rows)
+
+    # 4) Broad contains (pick longest token to reduce noise)
+    if not rows:
+        token = max(m.split("."), key=len)
+        rows = _rows_contains(token)
+        log.debug("resolve_one.contains_rows: %s", rows)
+
+    cands = _rank(m, rows)
+    lab, rid, conf, assumption = _choose(cands)
+    return lab, rid, conf, cands, assumption
+
+
+def resolve_entity(intent: QueryIntent) -> ResolvedEntity:
+    """Resolve `intent.mention` (and optional `mention_dst`) into graph ids.
+
+    WHY:
+        Downstream steps (Planner/GraphQuery) require canonical ids. This
+        function wraps two calls to `resolve_one` and returns a structured
+        `ResolvedEntity` suitable for Agent state.
+
+    Args:
+        intent: Parsed user intent carrying `mention` and `mention_dst`.
+
+    Returns:
+        A `ResolvedEntity` with:
+            - resolved_label/resolved_id/confidence (source)
+            - candidates (ranked alternatives)
+            - optional assumption message for UI/planner
+            - *_dst fields if `mention_dst` is provided
+
+    Examples:
+        >>> from src.code_graph_rag.agent.models import QueryIntent
+        >>> qi = QueryIntent(action="list_callers", mention="main")
+        >>> resolve_entity(qi)  # doctest: +SKIP
+        ResolvedEntity(...)
+    """
+    src_lab, src_id, src_conf, src_cands, src_assump = resolve_one(
+        intent.mention or ""
+    )
+    log.debug("resolve_entity.source: %s, %s, %s, %s, %s", src_lab, src_id, src_conf, src_cands, src_assump)
+    dst_lab, dst_id, dst_conf, dst_cands, dst_assump = (None, None, 0.0, [], None)
+
+    if intent.mention_dst:
+        dst_lab, dst_id, dst_conf, dst_cands, dst_assump = resolve_one(
+            intent.mention_dst
+        )
+        log.debug("resolve_entity.destination: %s, %s, %s, %s, %s", dst_lab, dst_id, dst_conf, dst_cands, dst_assump)
+
+    assumption = src_assump or dst_assump
+    return ResolvedEntity(
+        resolved_label=src_lab,
+        resolved_id=src_id,
+        confidence=src_conf,
+        candidates=src_cands,
+        assumption=assumption,
+        resolved_label_dst=dst_lab,
+        resolved_id_dst=dst_id,
+        confidence_dst=dst_conf,
+        candidates_dst=dst_cands,
+    )

--- a/src/code_graph_rag/agent/resolver.py
+++ b/src/code_graph_rag/agent/resolver.py
@@ -302,6 +302,7 @@ def resolve_entity(intent: QueryIntent) -> ResolvedEntity:
     log.debug("resolve_entity.source: %s, %s, %s, %s, %s", src_lab, src_id, src_conf, src_cands, src_assump)
     dst_lab, dst_id, dst_conf, dst_cands, dst_assump = (None, None, 0.0, [], None)
 
+    log.debug("resolve_entity.intent.mention_dst: %s", intent.mention_dst)
     if intent.mention_dst:
         dst_lab, dst_id, dst_conf, dst_cands, dst_assump = resolve_one(
             intent.mention_dst

--- a/src/code_graph_rag/agent/utils/ranking.py
+++ b/src/code_graph_rag/agent/utils/ranking.py
@@ -1,0 +1,210 @@
+"""Ranking helpers for EntityResolver.
+
+This module provides deterministic scoring and ranking for candidate graph
+entities produced by the resolver's Cypher queries. It prioritizes exact
+matches, then suffix/name matches, and finally fuzzy token coverage, with a
+small type-based boost to prefer Method > Function > Class > Module.
+
+WHY:
+    Natural-language mentions like "main" or "pkg.mod.Class" can map to
+    multiple graph nodes. We need a stable, explainable scoring function to
+    pick the best candidate (or surface ambiguous options to the UI/Planner).
+
+PERF:
+    Pure-Python scoring; operates on already-limited result sets from Cypher
+    (LIMIT 50..400). Sorting is O(n log n) for small n.
+
+SECURITY:
+    No I/O here. All database interaction is performed in resolver.py with
+    parameterized Cypher.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Tuple
+
+from src.code_graph_rag.utils.logging_setup import get_logger
+log = get_logger(__name__)
+
+# Small, explainable priority bump by node type. Keeps behavior deterministic.
+# WHY:
+#   Short mentions (e.g., "main", "run") are ambiguous across Method/Function/
+#   Class/Module. In code Q&A, users typically refer to behaviors (methods/
+#   functions). A small, deterministic type-based boost nudges ranking toward
+#   executable entities, improving downstream CALLS/CALLEES queries.
+#
+# DESIGN:
+#   Method > Function > Class > Module with tiny margins (0.08/0.05/0.03/0.00).
+#   The boost must never overshadow a clearly better textual match; it only
+#   breaks near-ties among candidates with similar base_score tiers.
+#
+# RISK MITIGATION:
+#   Scores are clamped to [0,1]. Acceptance still depends on thresholds
+#   (e.g., >=0.80 auto-accept). Ambiguous 0.50–0.80 returns candidates for UI.
+_TYPE_BOOST: dict[str, float] = {
+    "Method": 0.08,
+    "Function": 0.05,
+    "Class": 0.03,
+    "Module": 0.00,
+}
+
+
+def _tokenize(s: str) -> list[str]:
+    """Split an identifier into searchable tokens.
+
+    The function normalizes separators ('.', '_') and splits camelCase to
+    improve fuzzy matching coverage.
+
+    Args:
+        s: Raw string, e.g. "pkg.mod.RequestHandler.handle_request".
+
+    Returns:
+        A list of lowercase tokens, e.g. ["pkg", "mod", "request", "handler",
+        "handle", "request"].
+
+    Examples:
+        >>> _tokenize("MyHTTPHandler.handle_get")
+        ['my', 'http', 'handler', 'handle', 'get']
+    """
+    # Normalize separators first.
+    s = s.replace(".", " ").replace("_", " ")
+    # Split camelCase and numbers.
+    parts = re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?![a-z])|\d+", s)
+    return [p.lower() for p in parts if p]
+
+
+def base_score(mention: str, label: str, qname: str, name: str | None) -> float:
+    """Compute a base 0..1 score from multiple matching tiers.
+
+    Tiers (first match wins):
+      1. 1.00 if mention == qname (exact qualified_name)
+      2. 0.90 if name and mention == name (exact simple name)
+      3. 0.85 if name and qname endswith ".name" and mention == name
+      4. 0.60..0.80 from token coverage between mention and qname
+
+    WHY:
+        Exact matches should dominate. When only partial hints exist, prefer
+        candidates whose tokens cover the mention more.
+
+    Args:
+        mention: Raw textual mention from the user.
+        label: Candidate label ("Module"|"Class"|"Function"|"Method"|...).
+        qname: Candidate canonical identifier (usually qualified_name).
+        name: Optional simple name of the candidate.
+
+    Returns:
+        A float in [0, 1].
+
+    Examples:
+        >>> base_score("pkg.mod.main", "Function", "pkg.mod.main", "main")
+        1.0
+        >>> base_score("main", "Function", "pkg.mod.main", "main")
+        0.9
+    """
+    m = mention.strip()
+    if not m:
+        return 0.0
+    if m == qname:
+        return 1.0
+    if name and m == name:
+        return 0.90
+    if name and qname.endswith("." + name) and (m == name):
+        return 0.85
+
+    # --- FUZZY RANKING EXPLANATION -----------------------------------------
+    # When exact tiers fail, we compute a *soft* similarity using token overlap.
+    # 1) Tokenization:
+    #    - We call _tokenize() which splits on dot/underscore and camelCase.
+    #      Example: "proj.web.RequestHandler.handle_request"
+    #      -> ["proj","web","request","handler","handle","request"]
+    # 2) Coverage metric:
+    #    - coverage = |tokens(mention) ∩ tokens(candidate)| / |tokens(mention)|
+    #      This measures how well the candidate *covers* the user's hint.
+    #      Example: mention={"request","handler"}, candidate contains both 
+    #      tokens(mention) ∩ tokens(candidate) = {"request","handler"} = 2
+    #      coverage = 2 / 2 = 1.0 (perfect match)
+    # 3) Score mapping:
+    #    - We map coverage into the 0.60..0.80 band:
+    #        score = 0.60 + 0.20 * coverage
+    #      Rationale:
+    #        * 0.60 is a weak-hint baseline (some relation but not strong).
+    #        * +0.20 rewards full coverage but *keeps fuzzy below exact tiers*:
+    #            0.90 (exact simple name) and 0.85 (suffix ".name").
+    # 4) Ordering guarantees:
+    #    - Fuzzy scores can never outrank exact-name/suffix tiers.
+    #    - A later, small type boost (Method/Function > Class > Module) can
+    #      break near ties among fuzzy candidates but cannot surpass strong
+    #      exact matches. This keeps ranking stable and explainable.
+    # -----------------------------------------------------------------------
+
+    # Fallback: fuzzy ranking coverage
+    mtoks = set(_tokenize(m))
+    qtoks = set(_tokenize(qname))
+    log.debug("base_score.mtoks: %s", mtoks)
+    log.debug("base_score.qtoks: %s", qtoks)
+    if not mtoks or not qtoks:
+        return 0.0
+    inter = len(mtoks & qtoks)
+    log.debug("base_score.intersection: %s", inter)
+    cov = inter / max(1, len(mtoks))
+    log.debug("base_score.coverage: %s", cov)
+    # Base fuzzy band 0.60..0.80 depending on coverage.
+    return 0.60 + 0.20 * cov
+
+
+def with_type_boost(score: float, label: str) -> float:
+    """Apply a small, explainable type boost.
+
+    WHY:
+        In code Q&A, users more often mean a method or function when using
+        short mentions like "main" or "handle". This nudge helps precision
+        without masking poor matches.
+
+    Args:
+        score: Base score in [0, 1].
+        label: Candidate label.
+
+    Returns:
+        Clamped score in [0, 1] after adding the label-specific boost.
+
+    Examples:
+        >>> with_type_boost(0.78, "Method")
+        0.86
+    """
+    return max(0.0, min(1.0, score + _TYPE_BOOST.get(label, 0.0)))
+
+
+def finalize_scores(
+    rows: Iterable[Tuple[str, str, str | None]], mention: str
+) -> list[tuple[str, str, float]]:
+    """Score and rank raw candidates deterministically.
+
+    Args:
+        rows: Iterable of (label, id_or_qname, simple_name_or_None).
+        mention: Original textual mention.
+
+    Returns:
+        A sorted list of (label, id, final_score) in descending score order,
+        with a stable tie-breaker on the candidate id.
+
+    Algorithm:
+        1) For each row, compute base_score().
+        2) Add with_type_boost().
+        3) Round to 6 decimals for stability/readability.
+        4) Sort by (-score, id).
+
+    Examples:
+        >>> rows = [("Function", "pkg.mod.main", "main"),
+        ...         ("Method", "pkg.App.main", "main")]
+        >>> finalize_scores(rows, "main")[0][0]
+        'Method'
+    """
+    log.debug("finalize_scores.rows: %s", rows)
+    log.debug("finalize_scores.mention: %s", mention)
+    out: list[tuple[str, str, float]] = []
+    for label, qid, name in rows:
+        s = base_score(mention, label, qid, name)
+        s = with_type_boost(s, label)
+        out.append((label, qid, round(s, 6)))
+    out.sort(key=lambda x: (-x[2], x[1]))
+    return out

--- a/src/code_graph_rag/agent/utils/utils.py
+++ b/src/code_graph_rag/agent/utils/utils.py
@@ -1,10 +1,68 @@
+from __future__ import annotations
+
+import os
+from typing import Any
 import mgclient
 
-def run_cypher_query(query: str) -> list[dict]:
-    conn = mgclient.connect(host="localhost", port=7687)
-    cursor = conn.cursor()
-    cursor.execute(query)
-    columns = [col.name for col in cursor.description]
-    rows = cursor.fetchall() 
+from src.code_graph_rag.utils.logging_setup import get_logger
+log = get_logger(__name__)
 
-    return [dict(zip(columns, rows))]
+
+def run_cypher_query(
+    query: str,
+    params: dict[str, Any] | None = None,
+    host: str | None = "localhost",
+    port: int | None = 7687,
+) -> list[dict[str, Any]]:
+    """Execute a parameterized Cypher query against Memgraph and return rows.
+
+    WHY:
+        Use parameters (e.g., $name) instead of string interpolation to avoid
+        Cypher injection and to enable planner reuse.
+
+    Args:
+        query: Cypher with $parameters, e.g. "MATCH (n) WHERE n.name=$name RETURN n.name AS name".
+        params: Mapping of parameter names to values, e.g. {"name": "main"}.
+        host: Override Memgraph host (defaults to MEMGRAPH_HOST or "localhost").
+        port: Override Memgraph port (defaults to MEMGRAPH_PORT or 7687).
+
+    Returns:
+        A list of dictionaries, one per row, keyed by returned column aliases.
+
+    Raises:
+        RuntimeError: If the query fails. The original exception is chained.
+
+    Example:
+        rows = run_cypher_query(
+            "MATCH (f:Function) WHERE f.name=$name RETURN f.qualified_name AS id, f.name AS name",
+            {"name": "main"},
+        )
+    """
+    log.debug("run_cypher_query.params: %s", params)
+    conn = mgclient.connect(host=host, port=port)
+    cur = conn.cursor()
+    try:
+        cur.execute(query, params or {})
+        # column names: be robust to driver variations (tuple vs object)
+        desc = cur.description or ()
+        colnames: list[str] = []
+        for c in desc:
+            name = getattr(c, "name", None)
+            if name is None:
+                try:
+                    name = c[0]  # type: ignore[index]
+                except Exception:
+                    name = str(c)
+            colnames.append(name)
+
+        rows = cur.fetchall() or []
+        # build list[dict] row-by-row
+        return [dict(zip(colnames, row)) for row in rows]
+    except Exception as e:  # pragma: no cover (you can refine specific exceptions)
+        raise RuntimeError(f"Cypher execution failed: {e}\nQuery: {query}\nParams: {params}") from e
+    finally:
+        try:
+            cur.close()
+        finally:
+            conn.close()
+

--- a/src/code_graph_rag/main.py
+++ b/src/code_graph_rag/main.py
@@ -6,7 +6,7 @@ from src.code_graph_rag.pipeline.build_knowledge_graph import build_knowledge_gr
 from src.code_graph_rag.agent.graph_agent import graph, GraphState
 
 Path("logs").mkdir(parents=True, exist_ok=True)
-setup_logging(level="INFO", log_file="logs/app.log", force=True)
+setup_logging(level="DEBUG", log_file="logs/app.log", force=True)
 
 def build_knowledge_graph() -> None:
     repo_path = Path("sample_repo")
@@ -38,5 +38,5 @@ def run_agent(question: str) -> None:
         log.info(f"Agent response: {response}")
 
 if __name__ == "__main__":
-    build_knowledge_graph()
-    # run_agent("Who calls foo?")
+    # build_knowledge_graph()
+    run_agent("Who calls sample_repo.app?")

--- a/tests/agent/test_resolver.py
+++ b/tests/agent/test_resolver.py
@@ -1,0 +1,116 @@
+import pytest
+from src.code_graph_rag.agent.models import QueryIntent
+from src.code_graph_rag.agent import resolver as R
+
+from src.code_graph_rag.utils.logging_setup import get_logger
+log = get_logger(__name__)
+
+@pytest.fixture(autouse=True)
+def patch_db(monkeypatch):
+    """Monkeypatch `run_cypher_query` to return deterministic fake rows.
+
+    Why:
+        - Decouple tests from Memgraph and the filesystem.
+        - Precisely control resolver branches (exact qname, exact name,
+          module suffix, broad contains) and their returned candidates.
+
+    Behavior:
+        - Uses the Cypher text to route to buckets in `fake` based on the
+          parameter values, emulating the resolver's allow-listed queries.
+    """
+    fake = {
+        "exact_qname:proj.app.main": [
+            {"label":"Function","id":"proj.app.main","name":"main"},
+        ],
+        "exact_name:main": [
+            {"label":"Method","id":"proj.core.App.main","name":"main"},
+            {"label":"Function","id":"proj.app.main","name":"main"},
+        ],
+        "suffix:util": [
+            {"label":"Module","id":"proj.pkg.util","name":"util.py"},
+        ],
+        "contains:handler": [
+            {"label":"Function","id":"proj.web.request_handler","name":"request_handler"},
+            {"label":"Method","id":"proj.web.RequestHandler.handle","name":"handle"},
+        ],
+    }
+
+    def fake_run(cypher: str, params=None):
+        params = params or {}
+        if "coalesce(n.qualified_name, '') = $q" in cypher:
+            return fake.get(f"exact_qname:{params.get('q')}", [])
+        if "WHERE n.name = name" in cypher and "Function" in cypher:
+            return fake.get(f"exact_name:{params.get('name')}", [])
+        if "m.qualified_name ENDS WITH '.' + name" in cypher:
+            return fake.get(f"suffix:{params.get('name')}", [])
+        if "CONTAINS t" in cypher:
+            return fake.get(f"contains:{params.get('t')}", [])
+        return []
+
+    monkeypatch.setattr(R, "run_cypher_query", fake_run)
+    yield
+
+def test_exact_qname_auto_accept():
+    """Exact qname should auto-accept with high confidence and no assumption.
+
+    Given ``mention='proj.app.main'``, the fake DB returns a Function node whose
+    ``qualified_name`` exactly matches the mention. The resolver must:
+      - set ``resolved_id`` to that qname,
+      - produce ``confidence >= 0.80``, and
+      - return no ``assumption`` message.
+    """
+    qi = QueryIntent(action="list_callees", mention="proj.app.main")
+    res = R.resolve_entity(qi)
+    log.debug("test_exact_qname_auto_accept.res: %s", res)
+
+    assert res.resolved_id == "proj.app.main"
+    assert res.confidence >= 0.80
+    assert not res.assumption
+
+
+def test_ambiguous_name_yields_candidates():
+    """Ambiguous short name should NOT auto-accept; return candidates instead.
+
+    Given ``mention='main'``, the fake DB returns both a Method and a Function
+    sharing the same simple name. Although type boosts make their scores close,
+    the win-margin guard prevents an overconfident auto-pick. The resolver must:
+      - leave ``resolved_id`` as ``None``,
+      - return at least two ``candidates``, and
+      - provide an ``assumption`` message indicating ambiguity.
+    """
+    qi = QueryIntent(action="list_callers", mention="main")
+    res = R.resolve_entity(qi)
+    log.debug("test_ambiguous_name_yields_candidates.res: %s", res)
+
+    assert res.resolved_id is None           # vì score có thể < 0.8
+    assert len(res.candidates) >= 2
+    assert res.assumption
+
+def test_suffix_module_match():
+    """Module stem/suffix should surface Module candidates for inspection.
+
+    Given ``mention='util'``, the resolver queries Modules whose
+    ``qualified_name`` ends with ``.util`` (or equals/name match). Expect the
+    candidate list to include ``proj.pkg.util``.
+    """
+    qi = QueryIntent(action="imports", mention="util")
+    res = R.resolve_entity(qi)
+    log.debug("test_suffix_module_match.res: %s", res)
+
+    assert any("proj.pkg.util" in c.id for c in res.candidates)
+
+def test_contains_token_fuzzy():
+    """Fuzzy CONTAINS fallback should still provide useful candidates.
+
+    Given ``mention='handler'`` and ``mention_dst='handle'``, the resolver falls
+    back to broad CONTAINS queries and ranks the results via token coverage.
+    Expect at least one side (source or destination) to yield candidates or an
+    ``assumption`` message, ensuring the Agent can proceed without exact
+    matches.
+    """
+    qi = QueryIntent(action="trace_flow", mention="handler", mention_dst="handle")
+    res = R.resolve_entity(qi)
+    log.debug("test_contains_token_fuzzy.res: %s", res)
+
+    assert len(res.candidates) > 0
+    assert res.candidates_dst or res.assumption


### PR DESCRIPTION
## Overview
- Integrates Phase 3.2 entity resolution to map user mentions to canonical graph IDs with confidence and ranked alternatives.
- Adds a resolver module using parameterized Cypher and deterministic ranking to improve security, performance, and ambiguity handling.
- Extends agent state/flow to store and use resolved entities before routing/query generation.
- Hardens intent parsing: ensures missing fields become `null` (None) rather than strings; clearer debug logs.

## Changes
- Parser:
  - N/A
- Agent:
  - graph_agent.py: add `resolve_entity_node` in flow; store resolution results in `GraphState`; wire step before routing.
  - models.py: create `ResolvedEntity` and `Candidate` models; remove unused `Route` literal; keep `Route` enum only.
  - intent.py: improve instructions/logging; enforce missing fields → `None` (not "none"/"null"); better error visibility.
  - resolver.py: new module with `resolve_entity` using parameterized Cypher, deterministic ranking, and confidence-based selection.
- Export/DB:
  - N/A
- Tests:
  - `test_resolver.py`: cover 4 cases (Exact qname, Ambiguous short name, Module stem/suffix and Fuzzy)
- Docs:
  - N/A

## How to Test
- Run agent tests:
  - `poetry run pytest tests/agent/test_resolver.py -q`

## Related
- Builds on Phase 3.1 (Router & Intent Parser).

## Notes
- Backward-compatible; no node/edge schema changes or migrations.