### PR TITLE
[Phase 3.2] feat: LLM Planner

### DIFF
--- a/src/code_graph_rag/agent/graph_agent.py
+++ b/src/code_graph_rag/agent/graph_agent.py
@@ -10,14 +10,17 @@ from src.code_graph_rag.agent.utils.utils import run_cypher_query
 from src.code_graph_rag.agent.intent import llm_parse_intent, decide_route
 from src.code_graph_rag.agent.resolver import resolve_entity
 from src.code_graph_rag.agent.models import QueryIntent, Route,  ResolvedEntity
+from src.code_graph_rag.agent.planner import make_plan
+from src.code_graph_rag.agent.models import ExplainPlan
 
 class GraphState(BaseModel):
     question: str | None = None
     intent: QueryIntent | None = None
     route: str | None = None
     resolve: ResolvedEntity | None = None
-    cypher_query: str | None = None
-    matched_node: list[dict] | None = None
+    plan: ExplainPlan | None = None
+    # cypher_query: str | None = None
+    # matched_node: list[dict] | None = None
     code_snippets: list[str] | None = None
     answer: str | None = None
 
@@ -51,8 +54,14 @@ def graph_query_node(state: GraphState):
 
     return {"cypher_query": result.content.strip()}
 
-def context_trieval_node(state: GraphState):
-    if not state.cypher_query:
+def plan_node(state: GraphState) -> GraphState:
+    if not (state.intent and state.resolve):
+        return state
+    state.plan = make_plan(state.intent, state.resolve)
+    return state
+
+def context_retrieval_node(state: GraphState):
+    if not state.plan:
         return {"matched_node": [], "code_snippets": []}
     
     results = run_cypher_query(state.cypher_query)
@@ -94,18 +103,21 @@ builder.add_node("UserQuestion", user_question_node)
 builder.add_node("ParseIntent", parse_intent_node)
 builder.add_node("Router", router_node)
 builder.add_node("ResolveEntity", resolve_entity_node)
-builder.add_node("GraphQuery", graph_query_node)
-builder.add_node("ContextRetrieval", context_trieval_node)
+builder.add_node("Plan", plan_node)
+# builder.add_node("GraphQuery", graph_query_node)
+builder.add_node("ContextRetrieval", context_retrieval_node)
 builder.add_node("AnswerGeneration", answer_generation_node)
 
 builder.set_entry_point("UserQuestion")
 builder.add_edge("UserQuestion", "ParseIntent")
 builder.add_edge("ParseIntent", "Router")
 builder.add_edge("Router", "ResolveEntity")
-builder.add_edge("ResolveEntity", "GraphQuery")
-builder.add_edge("GraphQuery", "ContextRetrieval" )
-builder.add_edge("ContextRetrieval", "AnswerGeneration")
-builder.set_finish_point("AnswerGeneration")
+builder.add_edge("ResolveEntity", "Plan")
+builder.set_finish_point("Plan")
+# builder.add_edge("ResolveEntity", "GraphQuery")
+# builder.add_edge("GraphQuery", "ContextRetrieval" )
+# builder.add_edge("ContextRetrieval", "AnswerGeneration")
+# builder.set_finish_point("AnswerGeneration")
 
 graph = builder.compile()
 

--- a/src/code_graph_rag/agent/models.py
+++ b/src/code_graph_rag/agent/models.py
@@ -82,3 +82,50 @@ class ResolvedEntity(BaseModel):
     resolved_id_dst: str | None = None
     confidence_dst: float = 0.0
     candidates_dst: list[Candidate] = []
+
+# 1) Allow-list step names (Literal keeps planner outputs type-safe)
+StepName = Literal[
+    "META", "CALLERS_TOP", "CALLEES_TOP", "IMPORTS", "NEIGHBORHOOD", "PATH",
+    "NODE_META", "METHODS_OF_CLASS", "INHERITS_DIRECT", "OVERRIDDEN_BY",
+    "ENTRY_FUNCS_BY_KEYWORD", "MODULE_OF_SYMBOL", "MODULES_DEPENDING_ON_EXTERNAL",
+    "PROJECT_EXTERNALS", "STATIC_ENRICH"
+]
+
+class PlanStep(BaseModel):
+    """One atomic retrieval/explain step chosen by the planner.
+
+    Args:
+        name: Step identifier from the allow-list.
+        params: Bounded parameter bag. No strings of Cypher.
+        required: If True, missing result will trigger retry/degrade in 3.4.
+
+    Example:
+        PlanStep(name="META", params={"id": "proj.app.main"}, required=True)
+    """
+    name: StepName
+    params: dict[str, Any] = Field(default_factory=dict)
+    required: bool = True
+
+class ExplainPlan(BaseModel):
+    """Planner output consumed by Phase 3.4.
+
+    Fields:
+        steps: Ordered list of steps (deterministic).
+        knobs: Global controls with tight bounds (depth/limit/k).
+
+    Notes:
+        - Bounds mirror QueryIntent clamps.
+        - Deterministic sort expected for test snapshots.
+    """
+    steps: list[PlanStep]
+    knobs: dict[str, int] = Field(default_factory=lambda: {"depth": 2, "limit": 50, "k": 3})
+
+    @field_validator("knobs")
+    @classmethod
+    def clamp_knobs(cls, v: dict[str, int]) -> dict[str, int]:
+        d = dict(v or {})
+        def clamp(x, lo, hi): return max(lo, min(hi, int(x)))
+        d["depth"] = clamp(d.get("depth", 2), 1, 5)
+        d["limit"] = clamp(d.get("limit", 50), 1, 200)
+        d["k"] = clamp(d.get("k", 3), 1, 5)
+        return d

--- a/src/code_graph_rag/agent/planner.py
+++ b/src/code_graph_rag/agent/planner.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+import json
+
+from langchain.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+from src.code_graph_rag.agent.llm import get_cypher_generate_model
+from src.code_graph_rag.agent.models import (
+    QueryIntent, ResolvedEntity, ExplainPlan, PlanStep
+)
+from src.code_graph_rag.utils.logging_setup import get_logger
+
+log = get_logger(__name__)
+
+ALLOWED_STEPS: tuple[str, ...] = (
+    "META", "CALLERS_TOP", "CALLEES_TOP", "IMPORTS", "NEIGHBORHOOD", "PATH",
+    "NODE_META", "METHODS_OF_CLASS", "INHERITS_DIRECT", "OVERRIDDEN_BY",
+    "ENTRY_FUNCS_BY_KEYWORD", "MODULE_OF_SYMBOL", "MODULES_DEPENDING_ON_EXTERNAL",
+    "PROJECT_EXTERNALS", "STATIC_ENRICH"
+)
+
+SCHEMA = """
+Return ONLY a JSON object:
+
+{
+  "steps": [
+    {"name": "<one of ALLOWED_STEPS>", "params": {...}, "required": true|false}
+  ],
+  "knobs": {"depth": 1, "limit": 50, "k": 3}
+}
+
+Rules:
+- JSON only (no prose, no code fences).
+- Use only names from ALLOWED_STEPS.
+- Bind params, do NOT write Cypher.
+- Mark evidence-producing steps (META, ENTRY_FUNCS_BY_KEYWORD, STATIC_ENRICH, PATH) as required when appropriate.
+- Respect bounds: depth<=5, limit<=200, k<=5.
+- Deterministic ordering: required steps first; then by name ASC.
+"""
+
+CATALOG = """
+ALLOWED_STEPS:
+- META{id}
+- CALLERS_TOP{id, limit}
+- CALLEES_TOP{id, limit}
+- IMPORTS{id, limit}
+- NEIGHBORHOOD{id, depth, limit}
+- PATH{src, dst, k?}
+- NODE_META{ids}
+- METHODS_OF_CLASS{id, limit}
+- INHERITS_DIRECT{id, limit}
+- OVERRIDDEN_BY{id, limit}
+- ENTRY_FUNCS_BY_KEYWORD{kw, limit}
+- MODULE_OF_SYMBOL{id}
+- MODULES_DEPENDING_ON_EXTERNAL{package, limit}
+- PROJECT_EXTERNALS{project, limit}
+- STATIC_ENRICH{path, start_line, end_line} OR {from, take}
+"""
+
+GRAPH_RULES = "Labels: Project, Package, Module, Class, Function, Method, File, Folder, ExternalPackage. Edges (subset): DEFINES, DEFINES_METHOD, CALLS, IMPORTS, INHERITS, OVERRIDES, DEPENDS_ON_EXTERNAL."
+
+
+def make_plan(intent: QueryIntent, resolved: ResolvedEntity) -> ExplainPlan:
+    """Generate an ExplainPlan using an LLM with strict post-validation.
+
+    The function constructs system and user prompts, invokes the configured
+    LLM to obtain a JSON plan, then validates and normalizes the result. It
+    never emits Cypher; only JSON metadata is produced.
+
+    Args:
+      intent: Parsed query intent provided by the intent router.
+      resolved: Entity resolution results (e.g., qualified_name) for symbols.
+
+    Returns:
+      ExplainPlan: A plan with allowed steps sorted deterministically and
+      optional knobs carried through.
+
+    Example:
+      plan = make_plan(intent, resolved)
+      for step in plan.steps:
+          ...
+    """
+    system_prompt = "\n".join([
+        SCHEMA,
+        "-----",
+        "CATALOG:",
+        CATALOG,
+        "-----",
+        "GRAPH_RULES:",
+        GRAPH_RULES,
+    ])
+    user_payload = json.dumps({
+        "intent": intent.model_dump(),
+        "resolved": resolved.model_dump(),
+    }, ensure_ascii=False)
+
+    llm = get_cypher_generate_model(temperature=0.0, seed=42, json_mode=True, max_tokens=800)
+    prompt = ChatPromptTemplate.from_messages(
+        [("system", system_prompt), ("user", "{{ u }}")],
+        template_format="jinja2",
+    )
+    # log.debug("make_plan.prompt:\n %s", prompt.messages[1].content)
+    raw = (prompt | llm | StrOutputParser()).invoke({"u": user_payload})
+    log.debug("make_plan.raw: %s", raw)
+
+    # SECURITY/DETERMINISM: Filter to the allow-list, drop unknown steps,
+    # coerce params to dicts, default required, then sort with required
+    # steps first and name ASC to keep outputs stable.
+    # TODO(maintainers): Clamp knobs to bounds (depth<=5, limit<=200, k<=5).
+    data = json.loads(raw)
+    # Hard safety: filter/normalize
+    steps = data.get("steps") or []
+    cleaned: list[PlanStep] = []
+    for s in steps:
+        name = str(s.get("name", "")).strip()
+        if name not in ALLOWED_STEPS:
+            continue
+        params = dict(s.get("params") or {})
+        required = bool(s.get("required", True))
+        cleaned.append(PlanStep(name=name, params=params, required=required))
+
+    knobs = dict(data.get("knobs") or {})
+    plan = ExplainPlan(
+        steps=sorted(cleaned, key=lambda s: (not s.required, s.name)),
+        knobs=knobs,
+    )
+    log.debug("make_plan.explain_plan: %s", plan.model_dump())
+    return plan

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -1,0 +1,434 @@
+# tests/agent/test_planner.py
+import json
+import pytest
+
+from src.code_graph_rag.agent import planner as P
+from src.code_graph_rag.agent.models import QueryIntent, ResolvedEntity
+
+@pytest.fixture(autouse=True)
+def _no_real_llm(monkeypatch):
+    class _DummyLLM:
+        def invoke(self, x):
+            return x
+    monkeypatch.setattr(P, "get_cypher_generate_model", lambda **_: _DummyLLM())
+
+def _patch_prompt_to_chain(monkeypatch, chain):
+    """Patch ChatPromptTemplate.from_messages(...) to return our stubbed chain.
+
+    Accepts arbitrary kwargs (e.g., template_format="jinja2") to mirror production code.
+    """
+    monkeypatch.setattr(
+        P,
+        "ChatPromptTemplate",
+        type("X", (object,), {"from_messages": staticmethod(lambda *_a, **_kw: chain)}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1) Happy path: required-first ordering & stable sorting
+# ---------------------------------------------------------------------------
+def test_required_first_and_stable_sorting(patch_chain, monkeypatch):
+    """Ensure required steps are ordered before non-required, and names are
+    sorted deterministically within each group."""
+    payload = {
+        "steps": [
+            {"name": "CALLERS_TOP", "params": {"id": "X", "limit": 10}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 10, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+
+    assert names[0] == "META"  # required first
+    # Only two steps; sorting within groups is implied by the result
+
+
+# ---------------------------------------------------------------------------
+# 2) Filter out disallowed steps
+# ---------------------------------------------------------------------------
+def test_filter_disallowed_steps(patch_chain, monkeypatch):
+    """Steps not present in the allowed list (e.g., 'GRAPHOPS') must be dropped."""
+    payload = {
+        "steps": [
+            {"name": "GRAPHOPS", "params": {"id": "X"}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 50, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    assert all(s.name != "GRAPHOPS" for s in plan.steps)
+    assert any(s.name == "META" for s in plan.steps)
+
+
+# ---------------------------------------------------------------------------
+# 3) Clamp knobs to safe bounds
+# ---------------------------------------------------------------------------
+def test_knobs_clamped_to_bounds(patch_chain, monkeypatch):
+    """Knobs returned by the LLM must be clamped to safe bounds:
+    depth<=5, limit<=200, k<=5."""
+    payload = {"steps": [], "knobs": {"depth": 99, "limit": 999, "k": 9}}
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    assert plan.knobs["depth"] <= 5
+    assert plan.knobs["limit"] <= 200
+    assert plan.knobs["k"] <= 5
+
+
+# ---------------------------------------------------------------------------
+# 4) Default knobs when missing or partial
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "knobs_in, expected_defaults",
+    [
+        ({}, {"depth": 2, "limit": 50, "k": 3}),
+        ({"limit": 5}, {"depth": 2, "limit": 5, "k": 3}),
+    ],
+)
+def test_knobs_defaults_and_partial(patch_chain, monkeypatch, knobs_in, expected_defaults):
+    """If knobs are missing or partially provided, defaults are filled and
+    still subject to clamping."""
+    payload = {"steps": [], "knobs": knobs_in}
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    assert plan.knobs["depth"] == expected_defaults["depth"]
+    assert plan.knobs["limit"] == expected_defaults["limit"]
+    assert plan.knobs["k"] == expected_defaults["k"]
+
+
+# ---------------------------------------------------------------------------
+# 5) Required default = True
+# ---------------------------------------------------------------------------
+def test_required_defaults_to_true(patch_chain, monkeypatch):
+    """A step without an explicit 'required' flag should default to True."""
+    payload = {
+        "steps": [
+            {"name": "META", "params": {"id": "X"}},  # required missing
+            {"name": "CALLERS_TOP", "params": {"id": "X", "limit": 10}, "required": False},
+        ],
+        "knobs": {"depth": 2, "limit": 10, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    assert plan.steps[0].name == "META"
+    assert plan.steps[0].required is True
+
+
+# ---------------------------------------------------------------------------
+# 6) Params passthrough & normalization
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "params_in, expected_out",
+    [
+        ({"id": "X", "limit": 10}, {"id": "X", "limit": 10}),  # normal dict
+        ({}, {}),  # empty dict
+        (None, {}),  # missing params treated as {}
+        ([], {}),  # list -> dict([]) -> {}
+    ],
+)
+def test_params_passthrough_and_normalization(patch_chain, monkeypatch, params_in, expected_out):
+    """Planner should pass-through params as a dict; if missing/None or an
+    empty list, it should normalize to {} and not crash."""
+    payload = {
+        "steps": [
+            {"name": "META", "params": {"id": "X"}, "required": True},
+            {"name": "CALLERS_TOP", "params": params_in, "required": False},
+        ],
+        "knobs": {"depth": 2, "limit": 10, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    # find CALLERS_TOP step
+    ct = next(s for s in plan.steps if s.name == "CALLERS_TOP")
+    assert ct.params == expected_out
+
+
+# ---------------------------------------------------------------------------
+# 7) Case sensitivity of step names
+# ---------------------------------------------------------------------------
+def test_step_name_case_sensitivity(patch_chain, monkeypatch):
+    """Step names must match the allow-list exactly; lowercase variants are
+    considered invalid and should be filtered out."""
+    payload = {
+        "steps": [
+            {"name": "meta", "params": {"id": "X"}, "required": True},  # invalid
+            {"name": "CALLERS_TOP", "params": {"id": "X", "limit": 10}, "required": False},
+        ],
+        "knobs": {"depth": 2, "limit": 10, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert "meta" not in names
+    assert "CALLERS_TOP" in names
+
+
+# ---------------------------------------------------------------------------
+# 8) Duplicate steps keep deterministic order
+# ---------------------------------------------------------------------------
+def test_duplicate_steps_deterministic_order(patch_chain, monkeypatch):
+    """When duplicates exist, required steps must appear first; within each
+    group ordering should be by name to keep determinism."""
+    payload = {
+        "steps": [
+            {"name": "META", "params": {"id": "X"}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 50, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    assert plan.steps[0].required is True
+    assert plan.steps[0].name == "META"
+
+
+# ---------------------------------------------------------------------------
+# 9) list_callers → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_list_callers_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for list_callers should include META and optionally
+    CALLERS_TOP; ordering must place required first."""
+    payload = {
+        "steps": [
+            {"name": "CALLERS_TOP", "params": {"id": "X", "limit": 5}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 5, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callers", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert names[0] == "META"
+    assert "CALLERS_TOP" in names
+
+
+# ---------------------------------------------------------------------------
+# 10) list_callees → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_list_callees_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for list_callees should include META and CALLEES_TOP,
+    with required-first ordering."""
+    payload = {
+        "steps": [
+            {"name": "CALLEES_TOP", "params": {"id": "X", "limit": 7}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 7, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="list_callees", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert names[0] == "META"
+    assert "CALLEES_TOP" in names
+
+
+# ---------------------------------------------------------------------------
+# 15) imports → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_imports_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for imports should include META and IMPORTS."""
+    payload = {
+        "steps": [
+            {"name": "IMPORTS", "params": {"id": "X", "limit": 11}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 11, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="imports", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert names[0] == "META"
+    assert "IMPORTS" in names
+
+
+# ---------------------------------------------------------------------------
+# 11) inherits_tree → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_inherits_tree_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for inherits_tree should include META and structural
+    inheritance steps like INHERITS_DIRECT and possibly METHODS_OF_CLASS."""
+    payload = {
+        "steps": [
+            {"name": "METHODS_OF_CLASS", "params": {"id": "X", "limit": 9}, "required": False},
+            {"name": "INHERITS_DIRECT", "params": {"id": "X", "limit": 9}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 9, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="inherits_tree", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert names[0] == "META"
+    assert "INHERITS_DIRECT" in names
+    assert "METHODS_OF_CLASS" in names
+
+
+# ---------------------------------------------------------------------------
+# 12) overrides → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_overrides_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for overrides should include META and OVERRIDDEN_BY."""
+    payload = {
+        "steps": [
+            {"name": "OVERRIDDEN_BY", "params": {"id": "X", "limit": 8}, "required": False},
+            {"name": "META", "params": {"id": "X"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 8, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="overrides", mention="X", language="en")
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert names[0] == "META"
+    assert "OVERRIDDEN_BY" in names
+
+
+# ---------------------------------------------------------------------------
+# 13) depends_external → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_depends_external_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for depends_external should include a direct package-level
+    step like MODULES_DEPENDING_ON_EXTERNAL (often required)."""
+    payload = {
+        "steps": [
+            {"name": "MODULES_DEPENDING_ON_EXTERNAL", "params": {"package": "numpy", "limit": 5}, "required": True}
+        ],
+        "knobs": {"depth": 2, "limit": 5, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="depends_external", mention="numpy", language="en")
+    resolved = ResolvedEntity(resolved_id="numpy", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert names[0] == "MODULES_DEPENDING_ON_EXTERNAL"
+    # Check params were honored by the chain stub
+    step = plan.steps[0]
+    assert step.params.get("package") == "numpy"
+
+
+# ---------------------------------------------------------------------------
+# 14) trace_flow → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_trace_flow_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for trace_flow should include both META and PATH as
+    required steps, with PATH carrying src/dst/k."""
+    payload = {
+        "steps": [
+            {"name": "PATH", "params": {"src": "A", "dst": "B", "k": 3}, "required": True},
+            {"name": "META", "params": {"id": "A"}, "required": True},
+        ],
+        "knobs": {"depth": 2, "limit": 50, "k": 3},
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="trace_flow", mention="A", mention_dst="B", language="en", k_paths=3)
+    resolved = ResolvedEntity(resolved_id="A", resolved_id_dst="B")
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert set(names) >= {"META", "PATH"}
+    # Ensure PATH params persisted
+    path_step = next(s for s in plan.steps if s.name == "PATH")
+    assert path_step.params.get("src") == "A"
+    assert path_step.params.get("dst") == "B"
+    assert path_step.params.get("k") == 3
+
+
+# ---------------------------------------------------------------------------
+# 15) explain_function → minimal plan
+# ---------------------------------------------------------------------------
+def test_action_explain_function_minimal_plan(patch_chain, monkeypatch):
+    """Minimal plan for explain_function should include META and STATIC_ENRICH
+    as key steps, plus local context like NEIGHBORHOOD/CALLERS_TOP/CALLEES_TOP."""
+    payload = {
+        "steps": [
+            {"name": "CALLERS_TOP", "params": {"id": "X", "limit": 10}, "required": False},
+            {"name": "CALLEES_TOP", "params": {"id": "X", "limit": 10}, "required": False},
+            {"name": "NEIGHBORHOOD", "params": {"id": "X", "depth": 2, "limit": 10}, "required": False},
+            {"name": "STATIC_ENRICH", "params": {"from": "META", "take": "all"}, "required": True},
+            {"name": "META", "params": {"id": "X"}, "required": True}
+        ],
+        "knobs": {"depth": 2, "limit": 10, "k": 3}
+    }
+    chain = patch_chain(payloads=[json.dumps(payload)])
+    _patch_prompt_to_chain(monkeypatch, chain)
+
+    qi = QueryIntent(action="explain_function", mention="X", language="en", depth=2, limit=10)
+    resolved = ResolvedEntity(resolved_id="X", resolved_id_dst=None)
+
+    plan = P.make_plan(qi, resolved)
+    names = [s.name for s in plan.steps]
+    assert "META" in names and "STATIC_ENRICH" in names
+    assert "NEIGHBORHOOD" in names and "CALLERS_TOP" in names and "CALLEES_TOP" in names
+    # Required-first ordering must hold
+    assert plan.steps[0].required is True


### PR DESCRIPTION
## Overview
- Generate LLM planner that outputs ExplainPlan (JSON).
- Enforce allow-list step names and deterministic ordering of plan steps.
- Strengthen type safety via new models: StepName, PlanStep, ExplainPlan with knob clamping.

## Changes
- Parser:
  - N/A
- Agent:
  - planner.py:
    - Implemented `make_plan()` to call LLM, parse JSON, filter allow-list, and sort deterministically.
  - models.py:
    - Added `StepName` (allow-list), `PlanStep`, `ExplainPlan` with knob clamping and validation.
  - graph_agent.py:
    - Integrated planner node to generate ExplainPlan and store it in state.
- Export/DB:
  - N/A (no Cypher changes; planner emits JSON only).
- Tests:
  - test_planner.py:
    - Coverage for required-first ordering, allow-list filtering, knob clamping/defaults, params normalization, duplicates determinism, and minimal plans per action (callers/callees/imports/inherits/overrides/depends_external/trace_flow/explain_function).

## How to Test
- Run unit tests:
  - `poetry run pytest test_planner.py -q`

## Related
- Builds on entity resolution work (Phase 3.2).

## Notes
- Backward-compatibility: No breaking public API changes; planner output is additive and type-safe.
- No schema/Cypher changes; Memgraph not required for planner tests.
- Idempotency: Deterministic sort (required-first, then name ASC). Knobs clamped to depth≤5, limit≤200, k≤5.
- Security: Planner emits JSON only; no Cypher generation; later adapters must remain parameterized and Memgraph-compatible.